### PR TITLE
Only mark areas as blocked if they contain the attribute transient as…

### DIFF
--- a/mp/src/game/server/NavMesh/nav_area.cpp
+++ b/mp/src/game/server/NavMesh/nav_area.cpp
@@ -4633,6 +4633,11 @@ bool CNavArea::IsBlocked( int teamID, bool ignoreNavBlockers ) const
 	{
 		return false;
 	}
+	else if ( ( m_attributeFlags & NAV_MESH_TRANSIENT ) == false )
+	{
+		// This fixes bot pathfinding, only blocks areas that need to be checked! - Reece (06/12/20)
+		return false;
+	}
 
 #ifdef TERROR
 	if ( ( teamID == TEAM_SURVIVOR ) && ( m_attributeFlags & CNavArea::NAV_PLAYERCLIP ) )


### PR DESCRIPTION
# Fixed bot navigation issues.

## Description

This change is fairly simple and is the intended behavior.
We only need to check if a navmesh area is blocked if its marked by the mapper as transient.

## How Has This Been Tested?

I've used small maps such as cs_office and ran multiple rounds.
Typically after round 1 - 5 bots end up hugging walls as they have no area to build paths on.

-  Bots no longer get stuck on cs_office
-  Bots respect the attribute on cs_havana

## Screenshots:

No screenshots needed as this corrects the bot behaviour making the build more playable.

## How To Use It?

Add bots to the match and watch as bots no longer hug walls in small maps such as cs_office.

## Checklist:

I've done my best to match the original style of the nav_mesh.cpp file.
